### PR TITLE
Add requirements.txt file, add instructions for dependency installation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Absolutely Proprietary
 Compare your installed packages against Parabola's package blacklist
 
+# Dependencies
+* Python 2
+* `colorama`, `termcolor`, and `pyfiglet`.
+
+After installing Python 2, install dependencies: `pip install -r requirements.txt`
+
 # Example output
 ```
 discover::::[uses-nonfree][FIXME:package] depends on nonfree archlinux-appstream-data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+colorama
+termcolor
+pyfiglet


### PR DESCRIPTION
Adds a requirements.txt file containing the dependencies for the script.
Also adds a section to the README describing how to use pip to install them.