### PR TITLE
Remove redundant 'cut'

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from pyfiglet import figlet_format
 
 #Get local installed packages
 f1 = open("installed.txt", "w+")
-f1.write(subprocess.check_output(['bash', '-c', 'pacman -Q|cut -f 1 -d " "', 'shell=True']))
+f1.write(subprocess.check_output(['bash', '-c', 'pacman -Qq', 'shell=True']))
 f1.close()
 
 #Get Parabola blacklist


### PR DESCRIPTION
pacman -Qq provides the correctly formatted output, no need to |cut it