### PR TITLE
fix git clone fail and empty line IndexError

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Proprietary package detector. Compares your installed packages against Parabola'
 *Update - I thought it's better to remove all the ascii stuff so there are no external libs. Thanks for the PRs!*
 
 # Quick install & run
-`sudo pacman -S python && cd /tmp && git clone https://github.com/vmavromatis/absolutely-proprietary.git && cd absolutely-proprietary && python main.py`
+`curl -o - https://raw.githubusercontent.com/vmavromatis/absolutely-proprietary/master/run.sh | sh`
 
 Once done, you may run `less disgusting.txt` to view the detailed results. Explanation of terms:
 - *nonfree*: This package is blatantly nonfree software.

--- a/main.py
+++ b/main.py
@@ -43,12 +43,13 @@ print("Checking packages")
 cleaned_blacklist = {}
 
 for line in blacklist:
-    name = line.split(':')[0]
-    reason = ((line.split(':')[4]).split(']')[0]).strip().replace('[', '')
-    if reason == "":
-        reason = "nonfree"
-    if not reason in IGNORE_REASONS:
-        cleaned_blacklist[name] = reason
+    if len(line) > 0:
+        name = line.split(':')[0]
+        reason = ((line.split(':')[4]).split(']')[0]).strip().replace('[', '')
+        if reason == "":
+            reason = "nonfree"
+        if not reason in IGNORE_REASONS:
+            cleaned_blacklist[name] = reason
 
 proprietary = 0
 

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+sudo pacman -S python --needed
+cd /tmp
+if [[ -d "absolutely-proprietary" ]]; then
+    cd absolutely-proprietary
+    git pull
+else
+    git clone https://github.com/vmavromatis/absolutely-proprietary.git
+    cd absolutely-proprietary
+fi
+    python main.py
+


### PR DESCRIPTION
* There are empty lines in blacklist.txt. Added a check in main.py not to break because of them.
* If the absolutely-proprietary folder already exists in /tmp, the git clone will fail. I added a check to see if it exists and then pull instead of cloning. Written it in a shell script for cleaner code.
* Also re-added the --needed option to pacman. There's no need to reinstall an up-to-date version of Python.