### PR TITLE
 CLI arguments, no prettytable, optional save to tempfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /blacklist.txt
 /disgusting.txt
+/.idea
+

--- a/README.md
+++ b/README.md
@@ -3,8 +3,14 @@ Proprietary package detector for arch-based distros. Compares your installed pac
 
 *Update - I thought it's better to remove all the ascii stuff so there are no external libs. Thanks for the PRs!*
 
-# Quick install & run
-`curl -o - https://raw.githubusercontent.com/vmavromatis/absolutely-proprietary/master/run.sh | sh`
+# Install
+`git clone https://github.com/vmavromatis/absolutely-proprietary.git`  
+`cd absolutely-proprietary`
+# Update
+`cd absolutely-proprietary`  
+`git pull https://github.com/vmavromatis/absolutely-proprietary.git`
+# Run
+`python main.py [arguments]`
 
 Explanation of terms:
 - *nonfree*: This package is blatantly nonfree software.

--- a/main.py
+++ b/main.py
@@ -85,8 +85,8 @@ for line in blacklist_list:
 
         if reason == "":
             reason = "nonfree"
-        if not reason in IGNORE_REASONS:
-            cleaned_blacklist[name] = [reason, desc, alternatives]
+        if reason not in IGNORE_REASONS:
+            cleaned_blacklist[name] = [reason, alternatives, desc]
 
 proprietary = 0
 
@@ -136,9 +136,9 @@ if vars(args)["status"]:
 if vars(args)["alternative"]:
     # check if "reverse" is passed
     if vars(args)["reverse"]:
-        stallman_disapproves.sort(key=lambda x: x[3], reverse=True)
+        stallman_disapproves.sort(key=lambda x: x[2], reverse=True)
     else:
-        stallman_disapproves.sort(key=lambda x: x[3])
+        stallman_disapproves.sort(key=lambda x: x[2])
 
 # Reverse sorting if "reverse" argument is passed
 # but "status" and "alternative" is not
@@ -162,10 +162,10 @@ for item in stallman_disapproves:
         package_len = len(item[0])
     if len(item[1]) > status_len:
         status_len = len(item[1])
-    if len(item[2]) > description_len:
-        description_len = len(item[2])
-    if len(item[3]) > alternative_len:
-        alternative_len = len(item[3])
+    if len(item[2]) > alternative_len:
+        alternative_len = len(item[2])
+    if len(item[3]) > description_len:
+        description_len = len(item[3])
 
 # Create a temporary file
 _, tmp_file = tempfile.mkstemp()
@@ -173,31 +173,31 @@ with open(tmp_file, "w") as f:
     # Print first horizontal separator of table
     f.write(line_separator(package_len,
                            status_len,
-                           description_len,
-                           alternative_len))
+                           alternative_len,
+                           description_len))
     # Print header
     f.write("| {:<{}} | {:<{}} | {:<{}} | {:<{}} |\n"
             .format(header_name, package_len,
                     header_status, status_len,
-                    header_description, description_len,
-                    header_alternative, alternative_len))
+                    header_alternative, alternative_len,
+                    header_description, description_len))
     f.write(line_separator(package_len,
                            status_len,
-                           description_len,
-                           alternative_len))
+                           alternative_len,
+                           description_len))
     # Print rest of the table
     for item in stallman_disapproves:
         # print element
         f.write("| {:<{}} | {:<{}} | {:<{}} | {:<{}} |\n"
                 .format(item[0], package_len,
                         item[1], status_len,
-                        item[2], description_len,
-                        item[3], alternative_len))
+                        item[2], alternative_len,
+                        item[3], description_len))
         # print horizontal separator
         f.write(line_separator(package_len,
                                status_len,
-                               description_len,
-                               alternative_len))
+                               alternative_len,
+                               description_len))
 # Disable CLI line wrapping
 subprocess.call(["setterm", "-linewrap", "off"])
 # Print file

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+import os
 import subprocess
 import urllib.request
 import argparse
@@ -199,13 +200,42 @@ with open(tmp_file, "w") as f:
                                alternative_len))
 # Disable CLI line wrapping
 subprocess.call(["setterm", "-linewrap", "off"])
+# Print file
 subprocess.call(["cat", tmp_file])
 
+# Ask if file to be saved
 save_it = input("\nSave list to file? (Y/n) ")
 if "n" in save_it.lower():
+    # delete if no
     subprocess.call(["rm", "-f", tmp_file])
 else:
-    print("The list is saved at", tmp_file)
+    # ask for filename if yes
+    new_file = input("Save it to ({}): ".format(tmp_file))
+    if new_file == "":
+        new_file = tmp_file
+    else:
+        # get absolute path, treat tilde as user's home folder
+        new_file = os.path.abspath(os.path.expanduser(new_file))
+        # leave tmp_file if user doesn't have permission to create new dir
+        try:
+            os.makedirs(os.path.dirname(new_file), exist_ok=True)
+        except PermissionError:
+            print("You don't have the right permissions!")
+            new_file = tmp_file
+        # leave tmp_file if user doesn't have permission to create file
+    if tmp_file != new_file:
+        try:
+            # copy tmp_file to new_file
+            with open(new_file, "w") as nf:
+                with open(tmp_file) as tf:
+                    for line in tf:
+                        nf.write(line)
+        except PermissionError:
+            print("You don't have the right permissions!")
+            new_file = tmp_file
+
+    # Print save location and CLI view suggestions
+    print("The list is saved at", new_file)
     print("\nYou can review it from the command line\n"
           "using the \"less -S {0}\"\n"
-          "or, if installed, the \"most {0}\" commands".format(tmp_file))
+          "or, if installed, the \"most {0}\" commands".format(new_file))

--- a/main.py
+++ b/main.py
@@ -2,35 +2,46 @@
 import sys
 import subprocess
 import urllib.request
-from prettytable import PrettyTable
 import argparse
+import tempfile
+
 
 def format_entry(entry, max_line_length, delim=" "):
-    #accumulated line length
+    # accumulated line length
     ACC_length = 0
     words = entry.split(delim)
     formatted_entry = ""
     for word in words:
-        #if ACC_length + len(word) and a space is <= max_line_length
+        # if ACC_length + len(word) and a space is <= max_line_length
         if ACC_length + (len(word) + 1) <= max_line_length:
-            #append the word and a space
+            # append the word and a space
             formatted_entry = formatted_entry + word + delim
-            #length = length + length of word + length of space
+            # length = length + length of word + length of space
             ACC_length = ACC_length + len(word) + 1
         else:
-            #append a line break, then the word and a space
+            # append a line break, then the word and a space
             formatted_entry = formatted_entry + "\n" + word + delim
-            #reset counter of length to the length of a word and a space
+            # reset counter of length to the length of a word and a space
             ACC_length = len(word) + 1
     formatted_entry = formatted_entry[:-1]
     return formatted_entry
 
+
+def line_separator(w, x, y, z):
+    return "+-{:<{}}-+-{:<{}}-+-{:<{}}-+-{:<{}}-+\n" \
+        .format("-" * w, w, "-" * x, x, "-" * y, y, "-" * z, z)
+
+
 parser = argparse.ArgumentParser(description='Find proprietary packages')
-parser.add_argument('-f', '--full', action='store_true', help='Print every package not just nonfree')
-parser.add_argument('-r', '--reverse', action='store_true', help='Reverse the sort')
+parser.add_argument('-f', '--full', action='store_true',
+                    help='Print every package not just nonfree')
+parser.add_argument('-r', '--reverse', action='store_true',
+                    help='Reverse the sort')
 sort_group = parser.add_mutually_exclusive_group()
-sort_group.add_argument('-s', '--status', action='store_true', help='Sort the table by the status column')
-sort_group.add_argument('-a', '--alternative', action='store_true', help='Sort the table by the alternative column')
+sort_group.add_argument('-s', '--status', action='store_true',
+                        help='Sort the table by the status column')
+sort_group.add_argument('-a', '--alternative', action='store_true',
+                        help='Sort the table by the alternative column')
 args = parser.parse_args()
 
 BLACKLIST_URLS = [
@@ -54,12 +65,14 @@ RESET = "\033[0m" if IS_TTY else ""
 # Get local installed packages
 print("Retrieving local packages (including AUR)...")
 
-packages = subprocess.check_output(["pacman", "-Qq"]).decode().strip().split('\n')
+packages = subprocess.check_output(
+    ["pacman", "-Qq"]).decode().strip().split('\n')
 
 blacklist_list = []
 for url in BLACKLIST_URLS:
     print("Downloading {}".format(url))
-    blacklist_list.extend(urllib.request.urlopen(url).read().decode().strip().split('\n'))
+    blacklist_list.extend(
+        urllib.request.urlopen(url).read().decode().strip().split('\n'))
 
 blacklist_list = [bl for bl in blacklist_list if len(bl) > 0]
 print("Comparing local packages to remote...")
@@ -96,7 +109,7 @@ for line in blacklist_list:
         if reason == "":
             reason = "nonfree"
         if not reason in IGNORE_REASONS:
-            cleaned_blacklist[name] = [reason, desc, alternatives ]
+            cleaned_blacklist[name] = [reason, desc, alternatives]
 
 proprietary = 0
 
@@ -105,7 +118,10 @@ stallman_disapproves = []
 for package in packages:
     package = package.strip()
     if package in cleaned_blacklist:
-        stallman_disapproves.append([package, cleaned_blacklist[package][0], cleaned_blacklist[package][1], cleaned_blacklist[package][2]])
+        stallman_disapproves.append(
+            [package, cleaned_blacklist[package][0],
+             cleaned_blacklist[package][1],
+             cleaned_blacklist[package][2]])
         proprietary += 1
 
 total = len(packages)
@@ -119,23 +135,92 @@ else:
     INDEX_COLOR = RED
 
 # Print results
-print("{0}{1}\n{2} ABSOLUTELY PROPRIETARY PACKAGES INSTALLED\n{1}{3}".format(INDEX_COLOR, "=" * 45, proprietary, RESET))
-print("\nYour GNU/Linux is infected with {0}{2}{1} proprietary packages out of {0}{3}{1} total installed.\nYour Stallman Freedom Index is {0}{4:.2f}{1}\n"
-        .format(INDEX_COLOR, RESET, proprietary, total, stallmanfreedomindex))
+print("{0}{1}\n{2} ABSOLUTELY PROPRIETARY PACKAGES INSTALLED\n{1}{3}"
+      .format(INDEX_COLOR, "=" * 45, proprietary, RESET))
+print("\nYour GNU/Linux is infected with {0}{2}{1} proprietary packages"
+      "out of {0}{3}{1} total installed.\n"
+      "Your Stallman Freedom Index is {0}{4:.2f}{1}\n"
+      .format(INDEX_COLOR, RESET, proprietary, total, stallmanfreedomindex))
 
-table = PrettyTable(['Name', 'Status', 'Description', 'Libre Alternatives'])
-table.hrules=1
-table.align='l'
-for package in stallman_disapproves:
-    if package[1] != 'nonfree' and not args.full:
-        continue
-    table.add_row(package)
 
-if args.status:
-    table = table.get_string(sortby="Status", reversesort=args.reverse)
-elif args.alternative:
-    table = table.get_string(sortby="Libre Alternatives", reversesort=args.reverse)
+# Leave only "nonfree" packages in list if "full" argument is not passed
+if not vars(args)["full"]:
+    stallman_disapproves = \
+        [item for item in stallman_disapproves if item[1] == "nonfree"]
+
+# Sort by column "status" if "status" argument is passed
+if vars(args)["status"]:
+    # check if "reverse" is passed
+    if vars(args)["reverse"]:
+        stallman_disapproves.sort(key=lambda x: x[1], reverse=True)
+    else:
+        stallman_disapproves.sort(key=lambda x: x[1])
+
+# Sort by column "alternative" if "alternative" argument is passed
+if vars(args)["alternative"]:
+    # check if "reverse" is passed
+    if vars(args)["reverse"]:
+        stallman_disapproves.sort(key=lambda x: x[3], reverse=True)
+    else:
+        stallman_disapproves.sort(key=lambda x: x[3])
+
+# Reverse sorting if "reverse" argument is passed
+# but "status" and "alternative" is not
+if vars(args)["reverse"] \
+        and not vars(args)["status"] \
+        and not vars(args)["alternative"]:
+    stallman_disapproves.sort(reverse=True)
+
+# Store longest element's length in each stallman_disapproves list item
+package_len = 0
+status_len = 0
+description_len = 0
+alternative_len = 0
+for item in stallman_disapproves:
+    # replace newline characters with nothing
+    item[0] = item[0].replace("\n", "")
+    item[1] = item[1].replace("\n", "")
+    item[2] = item[2].replace("\n", "")
+    item[3] = item[3].replace("\n", "")
+    if len(item[0]) > package_len:
+        package_len = len(item[0])
+    if len(item[1]) > status_len:
+        status_len = len(item[1])
+    if len(item[2]) > description_len:
+        description_len = len(item[2])
+    if len(item[3]) > alternative_len:
+        alternative_len = len(item[3])
+
+# Create a temporary file
+_, tmp_file = tempfile.mkstemp()
+with open(tmp_file, "w") as f:
+    # Print first horizontal separator of table
+    f.write(line_separator(package_len,
+                           status_len,
+                           description_len,
+                           alternative_len))
+    # Print rest of the table
+    for item in stallman_disapproves:
+        # print element
+        f.write("| {:<{}} | {:<{}} | {:<{}} | {:<{}} |\n"
+                .format(item[0], package_len,
+                        item[1], status_len,
+                        item[2], description_len,
+                        item[3], alternative_len))
+        # print horizontal separator
+        f.write(line_separator(package_len,
+                               status_len,
+                               description_len,
+                               alternative_len))
+# Disable CLI line wrapping
+subprocess.call(["setterm", "-linewrap", "off"])
+subprocess.call(["cat", tmp_file])
+
+save_it = input("\nSave list to file? (Y/n) ")
+if "n" in save_it.lower():
+    subprocess.call(["rm", "-f", tmp_file])
 else:
-    table = table.get_string(sortby="Name", reversesort=args.reverse)
-
-print(table)
+    print("The list is saved at", tmp_file)
+    print("\nYou can review it from the command line\n"
+          "using the \"less -S {0}\"\n"
+          "or, if installed, the \"most {0}\" commands".format(tmp_file))

--- a/main.py
+++ b/main.py
@@ -7,9 +7,14 @@ import argparse
 import tempfile
 
 
-def line_separator(w, x, y, z):
+def table_separator(w, x, y, z):
     return "+-{:<{}}-+-{:<{}}-+-{:<{}}-+-{:<{}}-+\n" \
         .format("-" * w, w, "-" * x, x, "-" * y, y, "-" * z, z)
+
+
+def table_row(i1, l1, i2, l2, i3, l3, i4, l4):
+    return "| {:<{}} | {:<{}} | {:<{}} | {:<{}} |\n" \
+        .format(i1, l1, i2, l2, i3, l3, i4, l4)
 
 
 parser = argparse.ArgumentParser(description='Find proprietary packages')
@@ -164,20 +169,19 @@ for item in stallman_disapproves:
 _, tmp_file = tempfile.mkstemp()
 with open(tmp_file, "w") as f:
     # Print first horizontal separator of table
-    f.write(line_separator(package_len,
-                           status_len,
-                           alternative_len,
-                           description_len))
+    f.write(table_separator(package_len,
+                            status_len,
+                            alternative_len,
+                            description_len))
     # Print header
-    f.write("| {:<{}} | {:<{}} | {:<{}} | {:<{}} |\n"
-            .format(header_name, package_len,
-                    header_status, status_len,
-                    header_alternative, alternative_len,
-                    header_description, description_len))
-    f.write(line_separator(package_len,
-                           status_len,
-                           alternative_len,
-                           description_len))
+    f.write(table_row(header_name, package_len,
+                      header_status, status_len,
+                      header_alternative, alternative_len,
+                      header_description, description_len))
+    f.write(table_separator(package_len,
+                            status_len,
+                            alternative_len,
+                            description_len))
     # Print rest of the table
     for item in stallman_disapproves:
         # print element
@@ -185,35 +189,31 @@ with open(tmp_file, "w") as f:
         if len(item[2]) > 1:
             for sub in item[2]:
                 if first:
-                    f.write("| {:<{}} | {:<{}} | {:<{}} | {:<{}} |\n"
-                            .format(item[0], package_len,
-                                    item[1], status_len,
-                                    sub, alternative_len,
-                                    item[3], description_len))
+                    f.write(table_row(item[0], package_len,
+                                      item[1], status_len,
+                                      sub, alternative_len,
+                                      item[3], description_len))
                     first = False
                 else:
-                    f.write("| {:<{}} | {:<{}} | {:<{}} | {:<{}} |\n"
-                            .format("", package_len,
-                                    "", status_len,
-                                    sub, alternative_len,
-                                    "", description_len))
+                    f.write(table_row("", package_len,
+                                      "", status_len,
+                                      sub, alternative_len,
+                                      "", description_len))
         elif len(item[2]) == 1:
-            f.write("| {:<{}} | {:<{}} | {:<{}} | {:<{}} |\n"
-                    .format(item[0], package_len,
-                            item[1], status_len,
-                            item[2][0], alternative_len,
-                            item[3], description_len))
+            f.write(table_row(item[0], package_len,
+                              item[1], status_len,
+                              item[2][0], alternative_len,
+                              item[3], description_len))
         else:
-            f.write("| {:<{}} | {:<{}} | {:<{}} | {:<{}} |\n"
-                    .format(item[0], package_len,
-                            item[1], status_len,
-                            "", alternative_len,
-                            item[3], description_len))
+            f.write(table_row(item[0], package_len,
+                              item[1], status_len,
+                              "", alternative_len,
+                              item[3], description_len))
         # print horizontal separator
-        f.write(line_separator(package_len,
-                               status_len,
-                               alternative_len,
-                               description_len))
+        f.write(table_separator(package_len,
+                                status_len,
+                                alternative_len,
+                                description_len))
 # Disable CLI line wrapping
 subprocess.call(["setterm", "-linewrap", "off"])
 # Print file

--- a/main.py
+++ b/main.py
@@ -6,27 +6,6 @@ import argparse
 import tempfile
 
 
-def format_entry(entry, max_line_length, delim=" "):
-    # accumulated line length
-    ACC_length = 0
-    words = entry.split(delim)
-    formatted_entry = ""
-    for word in words:
-        # if ACC_length + len(word) and a space is <= max_line_length
-        if ACC_length + (len(word) + 1) <= max_line_length:
-            # append the word and a space
-            formatted_entry = formatted_entry + word + delim
-            # length = length + length of word + length of space
-            ACC_length = ACC_length + len(word) + 1
-        else:
-            # append a line break, then the word and a space
-            formatted_entry = formatted_entry + "\n" + word + delim
-            # reset counter of length to the length of a word and a space
-            ACC_length = len(word) + 1
-    formatted_entry = formatted_entry[:-1]
-    return formatted_entry
-
-
 def line_separator(w, x, y, z):
     return "+-{:<{}}-+-{:<{}}-+-{:<{}}-+-{:<{}}-+\n" \
         .format("-" * w, w, "-" * x, x, "-" * y, y, "-" * z, z)
@@ -94,7 +73,6 @@ for line in blacklist_list:
                 break
         if len(alternatives) > 0:
             alternatives = ','.join(alternatives)
-            alternatives = format_entry(alternatives, 30, ",")
         else:
             alternatives = ''
 
@@ -103,8 +81,6 @@ for line in blacklist_list:
         if reason_index != -1:
             desc = line[reason_index + len(reason) + 1:]
             desc = desc.strip()
-
-        desc = format_entry(desc, 90)
 
         if reason == "":
             reason = "nonfree"
@@ -141,7 +117,6 @@ print("\nYour GNU/Linux is infected with {0}{2}{1} proprietary packages"
       "out of {0}{3}{1} total installed.\n"
       "Your Stallman Freedom Index is {0}{4:.2f}{1}\n"
       .format(INDEX_COLOR, RESET, proprietary, total, stallmanfreedomindex))
-
 
 # Leave only "nonfree" packages in list if "full" argument is not passed
 if not vars(args)["full"]:
@@ -182,11 +157,6 @@ status_len = len(header_status)
 description_len = len(header_description)
 alternative_len = len(header_alternative)
 for item in stallman_disapproves:
-    # replace newline characters with nothing
-    item[0] = item[0].replace("\n", "")
-    item[1] = item[1].replace("\n", "")
-    item[2] = item[2].replace("\n", "")
-    item[3] = item[3].replace("\n", "")
     if len(item[0]) > package_len:
         package_len = len(item[0])
     if len(item[1]) > status_len:

--- a/main.py
+++ b/main.py
@@ -295,6 +295,19 @@ if tmp_file != new_file:
             # as regular file
             with open(new_file, "w") as f:
                 f.write(result)
+else:
+    if markdown:
+        with open(new_file, "w") as f:
+            f.write(as_markdown_header(header_name,
+                                       header_status,
+                                       header_alternative,
+                                       header_description))
+            for item in stallman_disapproves:
+                alt = "<br>".join(item[2])
+                f.write(as_markdown_body(item[0], item[1], alt, item[3]))
+    else:
+        with open(new_file, "w") as f:
+            f.write(result)
 
 # Delete empty temporary file
 if os.stat(tmp_file).st_size == 0:

--- a/main.py
+++ b/main.py
@@ -172,10 +172,15 @@ if vars(args)["reverse"] \
     stallman_disapproves.sort(reverse=True)
 
 # Store longest element's length in each stallman_disapproves list item
-package_len = 0
-status_len = 0
-description_len = 0
-alternative_len = 0
+# starting values set to header elements
+header_name = "Name"
+header_status = "Status"
+header_description = "Description"
+header_alternative = "Libre Alternatives"
+package_len = len(header_name)
+status_len = len(header_status)
+description_len = len(header_description)
+alternative_len = len(header_alternative)
 for item in stallman_disapproves:
     # replace newline characters with nothing
     item[0] = item[0].replace("\n", "")
@@ -195,6 +200,16 @@ for item in stallman_disapproves:
 _, tmp_file = tempfile.mkstemp()
 with open(tmp_file, "w") as f:
     # Print first horizontal separator of table
+    f.write(line_separator(package_len,
+                           status_len,
+                           description_len,
+                           alternative_len))
+    # Print header
+    f.write("| {:<{}} | {:<{}} | {:<{}} | {:<{}} |\n"
+            .format(header_name, package_len,
+                    header_status, status_len,
+                    header_description, description_len,
+                    header_alternative, alternative_len))
     f.write(line_separator(package_len,
                            status_len,
                            description_len,

--- a/main.py
+++ b/main.py
@@ -62,27 +62,19 @@ cleaned_blacklist = {}
 for line in blacklist_list:
     if len(line) > 0:
         splitted = line.split(':')
-
         name = splitted[0]
         reason = ((line.split(':')[4]).split(']')[0]).strip().replace('[', '')
-
         alternatives = []
         for alt in splitted[1:]:
             if len(alt) > 0 and "[" not in alt:
                 alternatives.append(alt.strip())
             else:
                 break
-        if len(alternatives) > 0:
-            alternatives = ','.join(alternatives)
-        else:
-            alternatives = ''
-
         desc = ''
         reason_index = line.find(reason + "]")
         if reason_index != -1:
             desc = line[reason_index + len(reason) + 1:]
             desc = desc.strip()
-
         if reason == "":
             reason = "nonfree"
         if reason not in IGNORE_REASONS:
@@ -162,8 +154,9 @@ for item in stallman_disapproves:
         package_len = len(item[0])
     if len(item[1]) > status_len:
         status_len = len(item[1])
-    if len(item[2]) > alternative_len:
-        alternative_len = len(item[2])
+    for sub in item[2]:
+        if len(sub) > alternative_len:
+            alternative_len = len(sub)
     if len(item[3]) > description_len:
         description_len = len(item[3])
 
@@ -188,11 +181,34 @@ with open(tmp_file, "w") as f:
     # Print rest of the table
     for item in stallman_disapproves:
         # print element
-        f.write("| {:<{}} | {:<{}} | {:<{}} | {:<{}} |\n"
-                .format(item[0], package_len,
-                        item[1], status_len,
-                        item[2], alternative_len,
-                        item[3], description_len))
+        first = True
+        if len(item[2]) > 1:
+            for sub in item[2]:
+                if first:
+                    f.write("| {:<{}} | {:<{}} | {:<{}} | {:<{}} |\n"
+                            .format(item[0], package_len,
+                                    item[1], status_len,
+                                    sub, alternative_len,
+                                    item[3], description_len))
+                    first = False
+                else:
+                    f.write("| {:<{}} | {:<{}} | {:<{}} | {:<{}} |\n"
+                            .format("", package_len,
+                                    "", status_len,
+                                    sub, alternative_len,
+                                    "", description_len))
+        elif len(item[2]) == 1:
+            f.write("| {:<{}} | {:<{}} | {:<{}} | {:<{}} |\n"
+                    .format(item[0], package_len,
+                            item[1], status_len,
+                            item[2][0], alternative_len,
+                            item[3], description_len))
+        else:
+            f.write("| {:<{}} | {:<{}} | {:<{}} | {:<{}} |\n"
+                    .format(item[0], package_len,
+                            item[1], status_len,
+                            "", alternative_len,
+                            item[3], description_len))
         # print horizontal separator
         f.write(line_separator(package_len,
                                status_len,

--- a/main.py
+++ b/main.py
@@ -186,7 +186,7 @@ with open(tmp_file, "w") as f:
     for item in stallman_disapproves:
         # print element
         first = True
-        if len(item[2]) > 1:
+        if len(item[2]) > 0:
             for sub in item[2]:
                 if first:
                     f.write(table_row(item[0], package_len,
@@ -199,11 +199,6 @@ with open(tmp_file, "w") as f:
                                       "", status_len,
                                       sub, alternative_len,
                                       "", description_len))
-        elif len(item[2]) == 1:
-            f.write(table_row(item[0], package_len,
-                              item[1], status_len,
-                              item[2][0], alternative_len,
-                              item[3], description_len))
         else:
             f.write(table_row(item[0], package_len,
                               item[1], status_len,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-prettytable

--- a/run.sh
+++ b/run.sh
@@ -9,6 +9,6 @@ else
     git clone https://github.com/vmavromatis/absolutely-proprietary.git
     cd absolutely-proprietary
 fi
-pip install -r requirements.txt -U
+# sudo pip install -r requirements.txt -U
 python main.py
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-   
+
 # Always prefer setuptools over distutils
 from setuptools import setup, find_packages
 # To use a consistent encoding
@@ -117,7 +117,7 @@ setup(
     #
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['prettytable'],  # Optional
+    install_requires=[''],  # Optional
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"


### PR DESCRIPTION
Removed the PrettyTable module and created argument handling without it.
Also, this version writes everything to a temporary file then prints the contents from there  
after disabling the line wrapping in the terminal.  
Then it prompts the user to save the file or not. Currently it just deletes the temp file if the answer is no or leaves it in /tmp if yes, and prints its location and suggests commands to view it from the command line.

The .idea in gitignore is there because I use PyCharm and it creates that directory.

Also reformatted the script to not have lines longer than 79 chars. (PEP 8)

I also replaced the install instructions in the readme because the cmd arguments make the sh script kinda pointless now. I could wrap it in still and have it also check for arguments but that'd be just redundant.