### PR TITLE
Improving Package Building

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -14,13 +14,13 @@ source=("git+https://github.com/vmavromatis/${_pkgname}.git")
 md5sums=('SKIP')
 
 pkgver() {
-    cd "${_gitname}"
+    cd "absolutely-proprietary"
     printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
 }
 
 package() {
-  cd "${_gitname}"
+  cd "absolutely-proprietary"
   python setup.py install --prefix=/usr --root="$pkgdir/" --optimize=1
-  install -Dm644 "$srcdir/${_gitname}/LICENSE.md" \
+  install -Dm644 "$srcdir/absolutely-proprietary/LICENSE" \
                  "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }

--- a/README.md
+++ b/README.md
@@ -7,13 +7,16 @@ Proprietary package detector for arch-based distros. Compares your installed pac
 https://aur.archlinux.org/packages/absolutely-proprietary/
 
 # Install
-`git clone https://github.com/vmavromatis/absolutely-proprietary.git`
-`cd absolutely-proprietary`
+`git clone https://github.com/vmavromatis/absolutely-proprietary.git` <br />
+`cd absolutely-proprietary`<br />
+`makepkg`<br />
+`sudo pacman -U absolutely-proprietary-git-r92.632ebf7-1-any.pkg.tar.zst`
 # Update
-`cd absolutely-proprietary`
+`cd absolutely-proprietary`<br />
 `git pull https://github.com/vmavromatis/absolutely-proprietary.git`
+
 # Run
-`python absolutely_proprietary/__init__.py [arguments]`
+`absolutely-proprietary [arguments]`
 
 Explanation of terms:
 - *nonfree*: This package is blatantly nonfree software.


### PR DESCRIPTION
My Commit with the updated Readme steps would allow for an easier use for users where they can run the 'absolutely-proprietary' command instead of having to run a script. this is done by updating PKGBUILD to work more stable and adding steps to the Readme to show the best way to install and run the package. 